### PR TITLE
Fix Migration script is not shown in Manual

### DIFF
--- a/source/updating/update-7.3.rst
+++ b/source/updating/update-7.3.rst
@@ -118,7 +118,7 @@ The installation from source takes more steps. If there are more file to restore
 Execute the migration script
 ****************************
 
-.. code-block::
+.. code-block:: shell
 
     su -c 'scripts/MigrateToZnuny7_3.pl --verbose' - znuny
 

--- a/source/updating/update-7.3.rst
+++ b/source/updating/update-7.3.rst
@@ -118,7 +118,7 @@ The installation from source takes more steps. If there are more file to restore
 Execute the migration script
 ****************************
 
-.. code-block::shell
+.. code-block::
 
     su -c 'scripts/MigrateToZnuny7_3.pl --verbose' - znuny
 

--- a/source/updating/update-7.3.rst
+++ b/source/updating/update-7.3.rst
@@ -131,7 +131,7 @@ Reinstall or Upgrade Add-ons (Packages)
 	
 .. note:: UpgradeAll can fail, if repositories are not reachable or configured, versions for your framework are not available, or packages have been renamed. In this case, you should upgarde your packages manually via the commandline or by installing/updating them via the package manager.
 
-.. code-block::shell
+.. code-block:: shell
 
     # Make sure all add-ons are correct installed after a patch level update
     su -c 'bin/znuny.Console.pl Admin::Package::ReinstallAll' - znuny


### PR DESCRIPTION
Currently the migration script code is not shown in the manual:

<img width="788" height="438" alt="Bildschirmfoto 2026-04-02 um 16 38 43" src="https://github.com/user-attachments/assets/258947f2-24da-44ba-b34a-45c158afc938" />


This is a problem since the 7.2. Apparently there is a syntax error. The 7.1 Manual is fine.